### PR TITLE
fix(eslint-config): set default env for test files

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -129,4 +129,14 @@ module.exports = {
   env: {
     es6: true,
   },
+  overrides: [
+    {
+      files: ['**/*.spec.js', '**/*.test.js'],
+      env: {
+        jest: true,
+        es6: true,
+        node: true,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
This is quite repetitive override which we adding for most of the projects using Jest (or `/* env jest */` per each test file) which can be addressed this way.