### PR TITLE
feat: introduce renovate-config

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@researchgate/renovate-config",
+  "version": "1.3.0",
+  "renovate-config": {
+    "default": {
+      "extends": [
+        "config:base",
+        "default:preserveSemverRanges",
+        "default:rebaseStalePrs",
+        "schedule:nonOfficeHours"
+      ],
+      "postUpdateOptions": [
+        "yarnDedupeHighest"
+      ],
+      "packageRules": [
+        {
+          "depTypeList": [
+            "devDependencies"
+          ],
+          "automerge": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Once published, it can be used in any `renovate.json` as follows:

```json
{
  "extends": ["@researchgate"]
}
```